### PR TITLE
Added the possibility to specify an object literal with default values

### DIFF
--- a/src/config/configProvider.js
+++ b/src/config/configProvider.js
@@ -1,16 +1,19 @@
 const _ = require('lodash');
 const ArgumentError = require('../errors').ArgumentError;
 
-module.exports.fromWebtaskContext = function(webtaskContext) {
+module.exports.fromWebtaskContext = function(webtaskContext, seed) {
   if (webtaskContext === null || webtaskContext === undefined) {
     throw new ArgumentError('Must provide a webtask context');
+  }
+  if (seed === null || typeof seed !== typeof {}) {
+    seed = {};
   }
 
   const defaultConfig = {
     AUTH0_RTA: 'auth0.auth0.com'
   };
 
-  const settings = _.assign(defaultConfig, process.env, webtaskContext.params, webtaskContext.secrets, {
+  const settings = _.assign(defaultConfig, seed, process.env, webtaskContext.params, webtaskContext.secrets, {
     NODE_ENV: 'production',
     HOSTING_ENV: 'webtask'
   });

--- a/tests/config/configProvider.js
+++ b/tests/config/configProvider.js
@@ -89,3 +89,33 @@ tape('configProvider#fromWebtaskContext should allow overwriting the RTA', funct
   t.equal(provider('AUTH0_RTA'), 'login.myappliance.local');
   t.end();
 });
+
+tape('configProvider#fromWebtaskContext should accept a seed object literal', function(t) {
+  const seed = { seedKey: 'seedValue' };
+  const provider = configProvider.fromWebtaskContext({}, seed);
+
+  t.ok(provider);
+  t.equal(provider('seedKey'), 'seedValue');
+  t.end();
+});
+
+tape('configProvider#fromWebtaskContext should override seeded values', function(t) {
+  const seed = { seedKey: 'seedValue' };
+  const provider = configProvider.fromWebtaskContext({
+    params: { seedKey: 'anotherValue' },
+    secrets: {}
+  }, seed);
+
+  t.ok(provider);
+  t.equal(provider('seedKey'), 'anotherValue');
+  t.end();
+});
+
+tape('configProvider#fromWebtaskContext a seed must be able to override the AUTH0_RTA', function(t) {
+  const seed = { AUTH0_RTA: 'not.auth0.auth0.com' };
+  const provider = configProvider.fromWebtaskContext({}, seed);
+
+  t.ok(provider);
+  t.equal(provider('AUTH0_RTA'), 'not.auth0.auth0.com');
+  t.end();
+});


### PR DESCRIPTION
to the configuration subsystem.

This will let extension developers add a set of production-related settings in code for use when an extension is installed in the gallery, while retaining the option of overriding these values in server/config.json during local development.