### PR TITLE
No access token

### DIFF
--- a/src/sessionManager.js
+++ b/src/sessionManager.js
@@ -83,7 +83,7 @@ SessionManager.prototype.createAuthorizeUrl = function(options) {
   var urlOptions = [
     'https://' + this.options.rta + '/authorize',
     '?client_id=' + encodeURIComponent(this.options.clientId),
-    '&response_type=token id_token',
+    '&response_type=' + options.responseType || 'token id_token',
     '&response_mode=form_post',
     '&scope=' + encodeURIComponent(scopes),
     '&expiration=' + (options.expiration || 36000),

--- a/src/sessionManager.js
+++ b/src/sessionManager.js
@@ -83,7 +83,7 @@ SessionManager.prototype.createAuthorizeUrl = function(options) {
   var urlOptions = [
     'https://' + this.options.rta + '/authorize',
     '?client_id=' + encodeURIComponent(this.options.clientId),
-    '&response_type=' + options.responseType || 'token id_token',
+    '&response_type=token id_token',
     '&response_mode=form_post',
     '&scope=' + encodeURIComponent(scopes),
     '&expiration=' + (options.expiration || 36000),
@@ -194,9 +194,12 @@ SessionManager.prototype.create = function(idToken, accessToken, options) {
       const payload = {
         sub: tokens[0].sub,
         email: tokens[0].email,
-        exp: tokens[0].exp,
-        access_token: accessToken
+        exp: tokens[0].exp
       };
+
+      if (!options.noAccessToken) {
+        payload.access_token = accessToken;
+      }
 
       return jwt.sign(payload, options.secret, {
         algorithm: 'HS256',


### PR DESCRIPTION
✏️ Changes
Added option to exclude admin's `accessToken` from `idToken` as a temporary solution of DAE 3.0 security.

🔗 References
Jira: https://auth0team.atlassian.net/browse/KEY-159

🎯 Testing
✅ This has been tested locally
✅ This has been tested in a webtask