### PR TITLE
Update node-auth version to latest, 2.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "async": "2.1.2",
-    "auth0": "^2.17.0",
+    "auth0": "^2.18.0",
     "bluebird": "^3.4.1",
     "jsonwebtoken": "^8.3.0",
     "jwks-rsa": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,10 +204,10 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-auth0@^2.17.0:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/auth0/-/auth0-2.17.1.tgz#267910eda5f6be9b12f1ae58bc7a86805576ae08"
-  integrity sha512-1AcQQoojpq/L8+YJZEqFnPU2YMp0B8OtvPow4sLxrd3zn++NRF0+tZJJgaC2J9UHPSm7ID9ra0pt5JrGKy4ugw==
+auth0@^2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/auth0/-/auth0-2.18.0.tgz#9360d7b2cb7bb201dc44c774032cfeefd8762a98"
+  integrity sha512-ke++pr8Iaq1niuNQt0CLj+RlEoOFwk1LeTgsI30StvL4bYHT+rO0kaFr7QdWdXON5dDHxqtaVDE9p7OvxBcF5Q==
   dependencies:
     bluebird "^2.10.2"
     jsonwebtoken "^8.3.0"


### PR DESCRIPTION
## ✏️ Changes
  
Updating auth0 dependency to latest version which adds support for the Prompts and Branding endpoints of the Auth0 Management API
  
## 🔗 References
  
https://github.com/auth0/node-auth0/pull/370
Needed for Auth0 SE demo platform updates
  
## 🎯 Testing
Verify `npm install` installs v2.18.0
   
🚫 This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
* Can this change be merged at any time? Yes
* What will the deployment of the change look like? Release a new version for use by https://github.com/auth0-extensions/auth0-source-control-extension-tools
* Does this need to be released in lockstep with something else? No
  
✅ This can be deployed any time