### PR TITLE
allow set custom headers to auth0 management client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-extension-tools",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-extension-tools",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "description": "A set of tools and utilities to simplify the development of Auth0 Extensions.",
   "main": "src/index.js",
   "dependencies": {

--- a/src/auth0/managementApi.js
+++ b/src/auth0/managementApi.js
@@ -87,7 +87,7 @@ module.exports.getClient = function(options) {
       throw new ArgumentError('The provided accessToken is invalid');
     }
 
-    return Promise.resolve(new auth0.ManagementClient({ domain: options.domain, token: options.accessToken }));
+    return Promise.resolve(new auth0.ManagementClient({ domain: options.domain, token: options.accessToken, headers: options.headers }));
   }
 
   if (options.clientId === null || options.clientId === undefined) {
@@ -108,6 +108,6 @@ module.exports.getClient = function(options) {
 
   return getAccessTokenCached(options.domain, options.clientId, options.clientSecret)
     .then(function(token) {
-      return new auth0.ManagementClient({ domain: options.domain, token: token });
+      return new auth0.ManagementClient({ domain: options.domain, token: token, headers: options.headers });
     });
 };

--- a/tests/auth0/managementApi.js
+++ b/tests/auth0/managementApi.js
@@ -275,6 +275,16 @@ tape('managementApi#getClient should create a client for accessToken', function(
     });
 });
 
+tape('managementApi#getClient should create a client for accessToken with headers', function(t) {
+  managementApi.getClient({ domain: 'foo', accessToken: 'def', headers: { customHeader: 'custom' } })
+    .then(function(auth0) {
+      t.ok(auth0);
+      const keys = Object.keys(auth0);
+      keys.forEach(key => auth0[key].resource && t.equal(auth0[key].resource.restClient.options.headers.customHeader, 'custom'));
+      t.end();
+    });
+});
+
 tape('managementApi#getClient should create a client for clientId/secret', function(t) {
   nock('https://tenant.auth0cluster.com')
     .post('/oauth/token')


### PR DESCRIPTION
## ✏️ Changes
  
In order to determine how often and which versions of our deploy extensions are being used, we need a way for them to report themselves when communicating with the API.
ManagementClient header was not configurable before this change. 
This commit provides a way to pass custom headers when creating ManagementClient.  

## 🔗 References
  
https://auth0team.atlassian.net/browse/DXEX-508

## 🎯 Testing
  
✅ This has been tested locally
 
